### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,15 +47,15 @@ pytest-cover
     :alt: PyPI Package monthly downloads
     :target: https://pypi.python.org/pypi/pytest-cover
 
-.. |wheel| image:: https://pypip.in/wheel/pytest-cover/badge.svg?style=flat
+.. |wheel| image:: https://img.shields.io/pypi/wheel/pytest-cover.svg?style=flat
     :alt: PyPI Wheel
     :target: https://pypi.python.org/pypi/pytest-cover
 
-.. |supported-versions| image:: https://pypip.in/py_versions/pytest-cover/badge.svg?style=flat
+.. |supported-versions| image:: https://img.shields.io/pypi/pyversions/pytest-cover.svg?style=flat
     :alt: Supported versions
     :target: https://pypi.python.org/pypi/pytest-cover
 
-.. |supported-implementations| image:: https://pypip.in/implementation/pytest-cover/badge.svg?style=flat
+.. |supported-implementations| image:: https://img.shields.io/pypi/implementation/pytest-cover.svg?style=flat
     :alt: Supported imlementations
     :target: https://pypi.python.org/pypi/pytest-cover
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pytest-cover))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pytest-cover`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.